### PR TITLE
Added ability to ensure that every push is delivered to Apple

### DIFF
--- a/lib/apn.js
+++ b/lib/apn.js
@@ -171,12 +171,18 @@ var Connection = function (optionArgs) {
 		
 	var handleTransmissionError = function(data) {
 		// Need to check message that errors
-		//	return failed notification to owner
-		//	resend all following notifications
-		if(data[0] == 8) {
+		// return failed notification to owner
+		if (data[0] == 8) {
+			self.socket.end();
+
+			if (typeof options.errorCallback != 'function') {
+				self.cachedNotes = [];
+				return;
+			}
+
 			var currentCache = self.cachedNotes;
 			self.cachedNotes = [];
-			self.socket.end();
+
 			// This is an error condition
 			var errorCode = data[1];
 			var identifier = bytes2int(data.slice(2,6), 4);
@@ -190,12 +196,6 @@ var Connection = function (optionArgs) {
 			// Notify callback of failed notification
 			if(typeof options.errorCallback == 'function') {
 				options.errorCallback(errorCode, note);
-			}
-			while(currentCache.length) {
-				note = currentCache.shift();
-				process.nextTick(function() {
-				self.sendNotification(note);
-				});
 			}
 		}
 	}


### PR DESCRIPTION
If you send many push notifications (10k) and 10th will have invalid token,
there is chance that 2k push notifications will be broken before broken pipe exception.
This commit adds checking for every push message and fix bug with close event listener.

closes #12.
