### PR TITLE
Fixes bug introduced by a3cf8b090b673f96b155734221b42631619eea55

### DIFF
--- a/lib/apn.js
+++ b/lib/apn.js
@@ -51,7 +51,7 @@ var Connection = function (optionArgs) {
 	};
 
 	var onDrain = function () {
-		while (writeBuffer.length && self.socket.bufferSize == 0) {
+		while (writeBuffer.length && self.socket.socket.bufferSize == 0) {
 			writeNotificationToSocket(writeBuffer.shift());
 		}
 	};


### PR DESCRIPTION
For me, the line introduced by the commit a3cf8b090b673f96b155734221b42631619eea55 breaks the library; no notifications are sent. The current code is `self.socket.bufferSize`. I think it should be `self.socket.socket.bufferSize`. I don't know why you need `socket.socket`, but it is consistent with code later on, in `writeNotificationToSocket`.

See https://github.com/argon/node-apn/pull/16

I'm using node v0.6.1.

One reason why I might be experiencing this and not other people is that I'm on a slow mobile Internet connection.
