### PR TITLE
The socket.end in the handleTransmissionError function seems to cause EPIPE errors...

### DIFF
--- a/lib/apn.js
+++ b/lib/apn.js
@@ -212,7 +212,7 @@ var Connection = function (optionArgs) {
 		//  perhaps we should keep an identifier with each writeBuffer
 		//  entry to know where to stop when cycling through cachedNotes
 		if (data[0] == 8) {
-			self.socket.end();
+			//self.socket.end();
 
 			if (!options.enhanced) {
 				cachedNotes = [];


### PR DESCRIPTION
...later in the socket close handler. Do we really need to close the socket on all packets coming from APNS? The connection seems to still be good after the error packet (to be fair I've only had the invalidToken errors).
