### PR TITLE
"note.encoding" should be removed before apn is sent out

### DIFF
--- a/lib/apn.js
+++ b/lib/apn.js
@@ -154,6 +154,7 @@ var Connection = function (optionArgs) {
 		var encoding = 'utf8';
 		if (note.encoding) {
 			encoding = note.encoding;
+			delete note.encoding;
 		}
 		var token = note.device.token;
 		var message = JSON.stringify(note);


### PR DESCRIPTION
"note.encoding" an option  on  node-apn side, not on Apple side
