### PR TITLE
Fix for feedback not working issue

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -148,7 +148,7 @@ Feedback.prototype.connect = function () {
 				this.deferredConnection.resolve();
 			}.bind(this));
 			
-		this.receiveBuffer = new Buffer(0);
+		this.readBuffer = new Buffer(0);
 		this.socket.on('data', this.receive.bind(this));
 		this.socket.on("error", this.destroyConnection.bind(this));
 		this.socket.once('close', this.resetConnection.bind(this));


### PR DESCRIPTION
The Feedback service was looking for the "gateway" parameter instead of the "address" parameter when looking up the feedback server's hostname, and one of the internal variables were mis-typed (this.readBuffer was initialized as this.receiveBuffer in feedback.js)
