### PR TITLE
Add rejectUnauthorized as an option.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -42,6 +42,7 @@ function Connection (options) {
 		ca: null,
 		gateway: 'gateway.push.apple.com',
 		port: 2195,
+		rejectUnauthorized: true,
 		enhanced: true,
 		errorCallback: undefined,
 		cacheLength: 100
@@ -133,6 +134,7 @@ Connection.prototype.connect = function () {
 		socketOptions.cert = this.certData;
 		socketOptions.passphrase = this.options.passphrase;
 		socketOptions.ca = this.options.ca;
+		socketOptions.rejectUnauthorized = this.options.rejectUnauthorized;
 		
 		this.socket = tls.connect(
 			this.options['port'],


### PR DESCRIPTION
When running a local apn proxy, the connection to the proxy is unauthorized. This adds a new option, rejectUnauthorized, set by default, which allows running over unauthorized connections.
