### PR TITLE
feedback service via proxy also requires rejectUnauthorized flag

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -42,6 +42,7 @@ function Feedback(options) {
 		ca: null,							/* Certificate Authority
 		address: 'feedback.push.apple.com',	/* feedback address */
 		port: 2196,							/* feedback port */
+		rejectUnauthorized: true,  /* Set this to false incase using a local proxy, reject otherwise */
 		feedback: false,					/* enable feedback service, set to callback */
 		errorCallback: false,				/* error handler to catch connection exceptions */
 		interval: 3600,						/* interval in seconds to connect to feedback service */
@@ -135,17 +136,13 @@ Feedback.prototype.connect = function () {
 		socketOptions.cert = this.certData;
 		socketOptions.passphrase = this.options.passphrase;
 		socketOptions.ca = this.options.ca;
+		socketOptions.rejectUnauthorized = this.options.rejectUnauthorized;
 		
 		this.socket = tls.connect(
 			this.options['port'],
 			this.options['address'],
 			socketOptions,
 			function () {
-				if (!this.socket.authorized) {
-					this.deferredConnection.reject(this.socket.authorizationError);
-					this.deferredConnection = null;
-				}
-				
 				debug("Connection established");
 				this.deferredConnection.resolve();
 			}.bind(this));


### PR DESCRIPTION
rejectUnauthorized flag in socket options needs to be applied to feedback service as well.
