### PR TITLE
add support for mdm push notifications

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -25,7 +25,7 @@ function Notification () {
  */
 Notification.prototype.clone = function (device) {
 	var notification = new Notification();
-	
+
 	notification.encoding = this.encoding;
 	notification.payload = this.payload;
 	notification.expiry = this.expiry;
@@ -36,7 +36,7 @@ Notification.prototype.clone = function (device) {
 	notification.badge = this.badge;
 	notification.sound = this.sound;
 	notification.newsstandAvailable = this.newsstandAvailable;
-	
+
 	return notification
 }
 
@@ -172,6 +172,10 @@ Notification.prototype.trim = function() {
 Notification.prototype.toJSON = function () {
 	if (this.payload === undefined) {
 		this.payload = {};
+	}
+	if (typeof this.mdm == 'string') {
+		this.payload.mdm = this.mdm;
+		return this.payload;
 	}
 	if (this.payload.aps === undefined) {
 		this.payload.aps = {};


### PR DESCRIPTION
This change is required to support push notifications to Mobile Device Management enrolled devices:

http://images.apple.com/ipad/business/docs/iOS_MDM_Mar12.pdf
