### PR TITLE
Q 0.9 has removed isResolved which breaks node-apn. Updated package json depenency to 0.8.x which solves it for now.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/argon/node-apn.git"
   },
   "dependencies": {
-  	"q": ">=0.8.5"
+  	"q": "0.8.x"
   },
   "engines": { "node": ">= 0.6.6" },
   "license": "MIT"


### PR DESCRIPTION
q was updated and has removed features. Dependency should not be as loose as higher than X version
