### PR TITLE
Fix for Notification.trim() and multibyte chars.

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -153,7 +153,7 @@ Notification.prototype.trim = function() {
 		if (length < tooLong) {
 			return length - tooLong;
 		}
-		this.alert = this.alert.substring(0, length - tooLong);
+		this.alert = this.truncateStringToBytes(this.alert, length - tooLong);
 		return tooLong;
 	}
 	else if(typeof this.alert == "object" && typeof this.alert.body == "string") {
@@ -161,10 +161,23 @@ Notification.prototype.trim = function() {
 		if (length < tooLong) {
 			return length - tooLong;
 		}
-		this.alert.body = this.alert.body.substring(0, length - tooLong);
+		this.alert.body = this.truncateStringToBytes(this.alert.body, length - tooLong);
 		return tooLong;
 	}
 	return -tooLong;
+}
+
+/**
+ * @private
+ */ 
+Notification.prototype.truncateStringToBytes = function(string, bytes) {
+  var truncated = string.substring(0, bytes);
+
+  while (Buffer.byteLength(truncated, this.encoding || 'utf8') > bytes) {
+    truncated = truncated.substring(0, truncated.length - 1);
+  }
+
+  return truncated;
 }
 
 /**


### PR DESCRIPTION
I noticed that after calling .trim() on a notification, I'd occasionally still see an 'invalidPayloadSize' error. After digging into the node-apn source a bit, I noticed that this was caused by assuming single byte chars in a string when trimming. For example, it would fail to trim enough hindi chars in an alert since it was using .substring() with a byte length. I added a small method to the Notification class to remove chars until the string actually meets the desired byte size.
