### PR TITLE
Feedback function is not necessary any more

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -74,10 +74,7 @@ function Feedback(options) {
 		this.on('error', this.options.errorCallback);
 	}
 
-	if (typeof this.options.feedback != 'function') {
-		throw new Error(-1, 'A callback function must be specified');
-	}
-	else {
+	if (typeof this.options.feedback == 'function') {
 		this.on('feedback', this.options.feedback);
 	}
 


### PR DESCRIPTION
The v1.3.0 crashes if feedback function is not defiend, even though the comments
suggest it should not be used.
