### PR TITLE
'url-args' is required for safari website notifications

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -228,15 +228,6 @@ Notification.prototype.setUrlArgs = function (urlArgs) {
 };
 
 /**
- * Set the urlArgs for the notification
- * @param {Object} [mdm] The mdm property for the payload.
- * @since v1.3.5
- */
-Notification.prototype.setUrlArgs = function (args) {
-this.urlArgs = args;
-};
-
-/**
  * If an alert object doesn't already exist create it and transfer any existing message into the .body property
  * @private
  * @since v1.2.0


### PR DESCRIPTION
here are the apple docs on this: https://developer.apple.com/library/prerelease/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html#//apple_ref/doc/uid/TP40013225-CH3-SW12
