### PR TITLE
Update connection.js to support a "shutdown" command

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -714,7 +714,7 @@ Connection.prototype.sendNotification = function (notification) {
 };
 
 /**
- * End connetions with APNS once we've finished sending all notifications
+ * End connections with APNS once we've finished sending all notifications
  */
 Connection.prototype.shutdown = function () {
 	this.shutdownPending = true;


### PR DESCRIPTION
This change adds a shutdown method to Connection that indicates to socketDrained that it should close connections once there are no more notifications to send. This allows APN to be run as part of a standalone program (e.g. a program that reads a list of notifications from a file). I've tested the change both with all successful messages, as well as when a few messages can't be sent. In both cases, the program does not shutdown until all messages that can be successfully sent are sent.
