### PR TITLE
Issue #50. Switch gateway depending on NODE_ENV.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,18 @@ This is intended as a brief introduction, please refer to the documentation in `
 	var apn = require('apn');
 
 ### Connecting
-Create a new connection to the APN gateway server using a dictionary of options. If you name your certificate and key files appropriately (`cert.pem` and `key.pem`) then the defaults should be suitable to get you up and running, the only thing you'll need to change is the `gateway` if you're in the sandbox environment.
+Create a new connection to the APN gateway server using a dictionary of options. If you name your certificate and key files appropriately (`cert.pem` and `key.pem`) then the defaults should be suitable to get you up and running.
 
 ```javascript
-	var options = { "gateway": "gateway.sandbox.push.apple.com" };
+	var apnConnection = new apn.Connection();
+```
 
-	var apnConnection = new apn.Connection(options);
+If the NODE_ENV environment variable is "production", then the library will connect to the official gateway, otherwise it will default to the sandbox gateway. You may also manually set the production option:
+
+```javascript
+    var options = { "production": true };
+
+    var apnConnection = new apn.Connection();
 ```
 
 Help with preparing the key and certificate files for connection can be found in the [wiki][certificateWiki]

--- a/doc/apn.markdown
+++ b/doc/apn.markdown
@@ -41,7 +41,7 @@ Options:
 
  - `passphrase` {String} The passphrase for the connection key, if required
 
- - `address` {String `gateway.push.apple.com`} The gateway server to connect to.
+ - `production` {Boolean} Whether this is a production or development server. Development server connects to sandbox. Default depends on `NODE_ENV`.
 
  - `port` {Number} Gateway port (Defaults to: `2195`)
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -31,7 +31,7 @@ if(process.env.DEBUG) {
  * @config {String} [pfx] File path for private key, certificate and CA certs in PFX or PKCS12 format. If supplied will be used instead of certificate and key above
  * @config {Buffer|String} [pfxData] PFX or PKCS12 format data containing the private key, certificate and CA certs. If supplied will be used instead of loading from disk.
  * @config {String} [passphrase] The passphrase for the connection key, if required
- * @config {String} [address="gateway.push.apple.com"] The gateway server to connect to.
+ * @config {Boolean} [production] Whether this is a production or development server. Development server connects to sandbox. Default depends on NODE_ENV.
  * @config {Number} [port=2195] Gateway port
  * @config {Boolean} [rejectUnauthorized=true] Reject Unauthorized property to be passed through to tls.connect()
  * @config {Boolean} [enhanced=true] Whether to use the enhanced notification format (recommended)
@@ -57,7 +57,7 @@ function Connection (options) {
 		pfx: null,
 		pfxData: null,
 		passphrase: null,
-		address: 'gateway.push.apple.com',
+        production: (process.env.NODE_ENV === "production"),
 		port: 2195,
 		rejectUnauthorized: true,
 		enhanced: true,
@@ -175,6 +175,7 @@ Connection.prototype.connect = function () {
 	this.deferredConnection = q.defer();
 	this.initialize().then(function () {
 		var socketOptions = {};
+        var address = (this.options['production']) ? "gateway.push.apple.com" : "gateway.sandbox.push.apple.com";
 
 		if(this.pfxData) {
 			socketOptions.pfx = this.pfxData;
@@ -193,7 +194,7 @@ Connection.prototype.connect = function () {
 
 		this.socket = tls.connect(
 			this.options['port'],
-			this.options['gateway'] || this.options['address'],
+            address,
 			socketOptions,
 			function () {
 				debug("Connection established");
@@ -215,10 +216,10 @@ Connection.prototype.connect = function () {
 		// The actual connection is delayed until after all the event listeners have
 		//  been attached.
 		if ("function" == typeof this.socket.connect ) {
-			this.socket.connect(this.options['port'], this.options['gateway'] || this.options['address']);
+			this.socket.connect(this.options['port'], address);
 		}
 		else {
-			socketOptions.socket.connect(this.options['port'], this.options['gateway'] || this.options['address']);
+			socketOptions.socket.connect(this.options['port'], address);
 		}
 	}.bind(this)).fail(function (error) {
 		debug("Module initialisation error:", error);


### PR DESCRIPTION
The address and gateway options have been replaced by a production boolean option.

If the NODE_ENV variable is "production", then it will connect to official gateway, otherwise it will default to the sandbox gateway.

Documentation has also been updated.

I only noticed now that I used spaces instead of tabs, sorry.
