### PR TITLE
Reliable Delivery

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -259,9 +259,11 @@ Connection.prototype.connect = function () {
  * @private
  */
 Connection.prototype.createConnection = function() {
+	
 	this.connect().then(function () {
+		var self = this;
+		var sock = this.socket;
 		this.failureCount = 0;
-
 		this.socket.socketId = this.socketId++;
 		this.socket.currentId = 0;
 		this.socket.cachedNotifications = [];


### PR DESCRIPTION
this commit encapsulates a few changes:

First, when a message is sent against a socket and produces an error, we know implicitly that all messages sent before it on the same socket were submitted successfully. In this case, we emit an "acknowledged" event for those messages.

Second, we provide an optional "ackTimeout" option to the constructor. If this is provided, after the timeout period (in ms), we submit a known bad token if there are any buffered messages. If this token produces an error before the previously queued messages, those messages will fire "acknowleged". This provides the consumer the ability to force acknowledgement after a specific amount of time. This timeout only fires if no other messages have already failed and interrupted the socket.
