### PR TITLE
Update feedback.js

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -103,6 +103,7 @@ Feedback.prototype.initialize = function () {
 	var readFile = q.nfbind(fs.readFile);
 
 	// Prepare PKCS#12 data if available
+	// Prepare PKCS#12 data if available
 	var pfxPromise = null;
 	if(this.options.pfx !== null || this.options.pfxData !== null) {
 		if(this.options.pfxData) {
@@ -111,34 +112,37 @@ Feedback.prototype.initialize = function () {
 		else if(Buffer.isBuffer(this.options.pfx)) {
 			pfxPromise = this.options.pfx;
 		}
-		else {
+		else if(this.options.pfx){
 			pfxPromise = readFile(this.options.pfx);
 		}
 	}
 
 	// Prepare Certificate data if available.
 	var certPromise = null;
-	if (this.options.certData) {
-		certPromise = this.options.certData;
+	if(this.options.cert !== null || this.options.certData !== null) {
+		if (this.options.certData) {
+			certPromise = this.options.certData;
+		}
+		else if(Buffer.isBuffer(this.options.key) || checkPEMType(this.options.cert, "CERTIFICATE")) {
+			certPromise = this.options.cert;
+		}
+		else if (this.options.cert){
+			// Nothing has matched so attempt to load from disk
+			certPromise = readFile(this.options.cert);
+		}
 	}
-	else if(Buffer.isBuffer(this.options.key) || checkPEMType(this.options.cert, "CERTIFICATE")) {
-		certPromise = this.options.cert;
-	}
-	else {
-		// Nothing has matched so attempt to load from disk
-		certPromise = readFile(this.options.cert);
-	}
-
 	// Prepare Key data if available
 	var keyPromise = null;
-	if (this.options.keyData) {
-		keyPromise = this.options.keyData;
-	}
-	else if(Buffer.isBuffer(this.options.key) || checkPEMType(this.options.key, "PRIVATE KEY")) {
-		keyPromise = this.options.key;
-	}
-	else {
-		keyPromise = readFile(this.options.key);
+	if(this.options.key !== null || this.options.keyData !== null) {
+		if (this.options.keyData) {
+			keyPromise = this.options.keyData;
+		}
+		else if(Buffer.isBuffer(this.options.key) || checkPEMType(this.options.key, "PRIVATE KEY")) {
+			keyPromise = this.options.key;
+		}
+		else if(this.options.key) {
+			keyPromise = readFile(this.options.key);
+		}
 	}
 
 	// Prepare Certificate Authority data if available.
@@ -167,6 +171,10 @@ Feedback.prototype.initialize = function () {
 };
 
 function checkPEMType(input, type) {
+	if (input == null) {
+		return false;
+	}
+
 	var matches = input.match(/\-\-\-\-\-BEGIN ([A-Z\s*]+)\-\-\-\-\-/);
 
 	if (matches != null) {


### PR DESCRIPTION
If 'cert' and 'key' are set to 'null', initialize fails in checkPEMType() trying to call match on 'null' 
'initialize' is trying to load 'cert' and 'key' files even if they are set to 'null' in options
