### PR TITLE
Update connection.js

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -120,34 +120,37 @@ Connection.prototype.initialize = function () {
 		else if(Buffer.isBuffer(this.options.pfx)) {
 			pfxPromise = this.options.pfx;
 		}
-		else {
+		else if (this.options.pfx) {
 			pfxPromise = readFile(this.options.pfx);
 		}
 	}
 
 	// Prepare Certificate data if available.
 	var certPromise = null;
-	if (this.options.certData) {
-		certPromise = this.options.certData;
-	}
-	else if(Buffer.isBuffer(this.options.cert) || checkPEMType(this.options.cert, "CERTIFICATE")) {
-		certPromise = this.options.cert;
-	}
-	else {
-		// Nothing has matched so attempt to load from disk
-		certPromise = readFile(this.options.cert);
+	if(this.options.cert !== null || this.options.certData !== null) {
+		if (this.options.certData) {
+			certPromise = this.options.certData;
+		}
+		else if(Buffer.isBuffer(this.options.cert) || checkPEMType(this.options.cert, "CERTIFICATE")) {
+			certPromise = this.options.cert;
+		}
+		else if (this.options.cert) {
+			certPromise = readFile(this.options.cert);
+		}
 	}
 
 	// Prepare Key data if available
 	var keyPromise = null;
-	if (this.options.keyData) {
-		keyPromise = this.options.keyData;
-	}
-	else if(Buffer.isBuffer(this.options.key) || checkPEMType(this.options.key, "PRIVATE KEY")) {
-		keyPromise = this.options.key;
-	}
-	else {
-		keyPromise = readFile(this.options.key);
+	if(this.options.key !== null || this.options.keyData !== null)  {
+		if (this.options.keyData) {
+			keyPromise = this.options.keyData;
+		}
+		else if(Buffer.isBuffer(this.options.key) || checkPEMType(this.options.key, "PRIVATE KEY")) {
+			keyPromise = this.options.key;
+		}
+		else if(this.options.key) {
+			keyPromise = readFile(this.options.key);
+		}
 	}
 
 	// Prepare Certificate Authority data if available.
@@ -176,6 +179,10 @@ Connection.prototype.initialize = function () {
 };
 
 function checkPEMType(input, type) {
+	if (input == null) {
+		return false;
+	}
+
 	var matches = input.match(/\-\-\-\-\-BEGIN ([A-Z\s*]+)\-\-\-\-\-/);
 
 	if (matches != null) {


### PR DESCRIPTION
If 'cert' and 'key' are set to 'null', initialize fails in checkPEMType() trying to call match on 'null' 
'initialize' is trying to load 'cert' and 'key' files even if they are explicitly set to 'null' in options
