### PR TITLE
Trigger feedback event even when there are no items

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -297,8 +297,8 @@ Feedback.prototype.destroyConnection = function (err) {
 Feedback.prototype.resetConnection = function () {
 	debug("Resetting connection");
 
-	if (this.options.batchFeedback && this.feedbackData.length > 0) {
-		debug("Emitting all feedback tokens");
+	if (this.options.batchFeedback) {
+		debug("Emitting " + this.feedbackData.length + " feedback tokens");
 		this.emit('feedback', this.feedbackData);
 		this.feedbackData = [];
 	}


### PR DESCRIPTION
Triggers the feedback service's `feedback` event with an empty result set when initialized with `{batchResults: true, interval: 0}`. 

When used this way, the feedback service runs once and disconnects after triggering a single `feedback` event. However, if there were no results, there was no way to know that the request succeeded.

We bumped into this problem while using the `Feedback` class to fetch the feedback as a response to a query from another service, when there was just no events from the feedback object at all for empty result sets. When used as a continuous service (non zero interval) it makes sense to not trigger the events for empty sets, but when fired for one query, it's more reasonable to trigger the empty event.
