### PR TITLE
Change reference to 'drain' event to 'completed'

### DIFF
--- a/doc/connection.markdown
+++ b/doc/connection.markdown
@@ -87,7 +87,7 @@ Emitted when the connection socket experiences an error. This may be useful for 
 
 Emitted when a notification has been sent to Apple - not a guarantee that it has been accepted by Apple, an error relating to it may occur later on. A notification may also be "transmitted" several times if a preceding notification caused an error requiring retransmission.
 
-### Event: 'drain'
+### Event: 'completed'
 
 `function () {}`
 


### PR DESCRIPTION
https://github.com/argon/node-apn/blob/master/lib/connection.js#L311 seems to indicate the doc uses the wrong event name here and confirmed by a problem I had today where a 'drain' event never was emitted (but 'completed' was).
