### PR TITLE
Fix grammar mistake in notification docs

### DIFF
--- a/doc/notification.markdown
+++ b/doc/notification.markdown
@@ -167,7 +167,7 @@ A UNIX timestamp when the notification should expire. If the notification cannot
 Provide one of the following values:
 
   * `10` - The push notification is sent to the device immediately. (Default)
-    > The push notification must trigger an alert, sound, or badge on the device. It is an error use this priority for a push that contains only the `content-available` key.
+    > The push notification must trigger an alert, sound, or badge on the device. It is an error to use this priority for a push notification that contains only the `content-available` key.
   * `5` - The push message is sent at a time that conserves power on the device receiving it.
 
 


### PR DESCRIPTION
As per https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/APNsProviderAPI.html.