### PR TITLE
Add missing apn.token definition to TS declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -163,3 +163,5 @@ export class Notification {
    */
   public urlArgs: string[];
 }
+
+export function token(token: (string | Buffer)) : string


### PR DESCRIPTION
Noticed the `apn.token()` function was missing from `idex.d.ts`