### PR TITLE
Add optional timestamp key to failure reason in TS declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,7 @@ export interface ResponseFailure {
   status?: string;
   response?: {
     reason: string;
+    timestamp?: string;
   };
 }
 


### PR DESCRIPTION
Added `timestamp` as an optional key (in case of 410 response)

From [Apple Doc](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html) Table 8-5

>If the value in the :status header is 410, the value of this key is the last time at which APNs confirmed that the device token was no longer valid for the topic.
Stop pushing notifications until the device registers a token with a later timestamp with your provider.