### PR TITLE
Updated type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,7 @@
+/// <reference types="node" />
+
+import { EventEmitter } from 'events';
+
 export interface ProviderToken {
   /**
    * The filename of the provider token key (as supplied by Apple) to load from disk, or a Buffer/String containing the key data.
@@ -70,7 +74,7 @@ export interface Responses {
   failed: ResponseFailure[];
 }
 
-export class Provider {
+export class Provider extends EventEmitter {
   constructor(options: ProviderOptions);
   /**
    * This is main interface for sending notifications. Create a Notification object and pass it in, along with a single recipient or an array of them and node-apn will take care of the rest, delivering a copy of the notification to each recipient.

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,28 @@ export interface ProviderOptions {
   connectionRetryLimit?: number;
 }
 
+interface ApsAlert {
+  body?: string
+  "loc-key"?: string
+  "loc-args"?: any[]
+  title?: string
+  "title-loc-key"?: string
+  "title-loc-args"?: any[]
+  action?: string
+  "action-loc-key"?: string
+}
+
+interface Aps {
+  alert?: string | ApsAlert
+  "launch-image"?: string
+  badge?: number
+  sound?: string
+  "content-available"?: undefined | 1
+  "mutable-content"?: undefined | 1
+  "url-args"?: string[]
+  category?: string
+}
+
 export interface ResponseSent {
   device: string;
 }
@@ -134,6 +156,8 @@ export class Notification {
    * This Object is JSON encoded and sent as the notification payload. When properties have been set on notification.aps (either directly or with convenience setters) these are added to the payload just before it is sent. If payload already contains an aps property it is replaced.
    */
   public payload: any;
+  public aps: Aps;
+
   /**
    * If supplied this payload will be encoded and transmitted as-is. The convenience setters will have no effect on the JSON output.
    */


### PR DESCRIPTION
* make `Provider` & `Notifications` classes extend event-emitter in the type-definitions (just like they do in the code)
* add a type definition for `Notifications#aps`
