### PR TITLE
Document `apn.Provider.shutdown()` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ This will result in the the following notification payload being sent to the dev
 {"messageFrom":"John Appelseed","aps":{"badge":3,"sound":"ping.aiff","alert":"\uD83D\uDCE7 \u2709 You have a new message"}}
 ```
 
-You should only create one `Provider` per-process for each certificate/key pair you have. You do not need to create a new `Provider` for each notification. If you are only sending notifications to one app then there is no need for more than one `Provider`.
+You should only create one `Provider` per-process for each certificate/key pair you have. You do not need to create a new `Provider` for each notification. If you are only sending notifications to one app then there is no need for more than one `Provider`. 
+
+If you are constantly creating `Provider` instances in your app, make sure to call `Provider.shutdown()` when you are done with each provider to release its resources and memory.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Closes #542.