### PR TITLE
Bump http2 version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+2.1.4:
+* Update APN dev endpoint (#528)
+* Update node-http2 fork to 2.1.3 (#471)
+
 2.1.3:
 * Add thread-id to notification payload (#484)
 * Workaround an issue where APNS would return an HTTP 500 and make the connection unusable (#449, #480)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 2.1.4:
 * Update APN dev endpoint (#528)
-* Update node-http2 fork to 2.1.3 (#471)
+* Update node-http2 fork to 2.1.4 (#471)
 
 2.1.3:
 * Add thread-id to notification payload (#484)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "debug": "^2.6.0",
-    "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.3.tar.gz",
+    "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
     "node-forge": "^0.6.48",
     "jsonwebtoken": "^7.2.1",
     "verror": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "debug": "^2.6.0",
-    "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.2.tar.gz",
+    "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.3.tar.gz",
     "node-forge": "^0.6.48",
     "jsonwebtoken": "^7.2.1",
     "verror": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apn",
   "description": "An interface to the Apple Push Notification service for Node.js",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "author": "Andrew Naylor <argon@mkbot.net>",
   "contributors": [
     {


### PR DESCRIPTION
@florianreinhart can you please create a release [here](https://github.com/node-apn/node-http2/releases) with the target master and tag it `apn-2.1.4`. Then, merge this pull request and `npm publish`. This pull request will not work until the release is tagged. Thanks! 

This will fully close the dreaded #471.