### PR TITLE
fix(endpoint): destroy after shutdown to clear heartbeat interval

### DIFF
--- a/lib/protocol/endpoint.js
+++ b/lib/protocol/endpoint.js
@@ -32,6 +32,7 @@ module.exports = function(dependencies) {
     this._lastSuccessPingedTime = null;
     this._pingedThreshold = (this.options.heartBeat || 60000) * 2.5;
     this._heartBeatInterval = (this.options.heartBeat || 60000);
+    this._destroyPending = false;
 
     options.ALPNProtocols = ["h2"];
 
@@ -155,6 +156,13 @@ module.exports = function(dependencies) {
         stream.emit("error", this.lastError);
       }
     });
+
+    // We make sure the endpoint is destroyed completely
+    // if this was requested. This avoids any internals
+    // of the endpoint keeping the event loop alive.
+    if (this._destroyPending) {
+      this.destroy();
+    }
   }
 
   Endpoint.prototype.createStream = function createStream() {
@@ -175,11 +183,12 @@ module.exports = function(dependencies) {
     return stream;
   };
 
-  Endpoint.prototype.close = function close() {
+  Endpoint.prototype.close = function close(destroyPending) {
     if (this._acquiredStreamSlots === 0) {
       this._connection.close();
     }
     this._closePending = true;
+    this._destroyPending = destroyPending;
   };
 
   Endpoint.prototype.destroy = function destroy() {

--- a/lib/protocol/endpointManager.js
+++ b/lib/protocol/endpointManager.js
@@ -92,7 +92,7 @@ module.exports = function(dependencies) {
 
   EndpointManager.prototype.shutdown = function shutdown() {
     for(let endpoint of this._endpoints) {
-      endpoint.close();
+      endpoint.close(true);
     }
 
     if (this._currentConnection) {


### PR DESCRIPTION
The heartbeat interval keeps the event loop alive. Originally, I just did an `.unref()` on the interval to fix the issue, but the [warnings in the docs](https://nodejs.org/dist/latest-v7.x/docs/api/timers.html#timers_timeout_unref) made me implement the fix in another way.

So now, after a shutdown, the endpoints get flagged as pending destroy. If the internal sockets closes and pending destroy is set, it finally calls the destroy clearing all heartbeat intervals.

Fixes #543.