### PR TITLE
change auth-key file .pem to .p8 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Create a new connection to the Apple Push Notification provider API, passing a d
 ```javascript
 var options = {
   token: {
-    key: "path/to/key.pem",
+    key: "path/to/APNsAuthKey_XXXXXXXXXX.p8",
     keyId: "key-id",
     teamId: "developer-team-id"
   },


### PR DESCRIPTION
I noticed the example showing a `.pem` file as a token key, when i got a `.p8` file from Apple - tested that it works.