### PR TITLE
update node-forge to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "debug": "^2.6.0",
     "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
-    "node-forge": "^0.6.48",
+    "node-forge": "^0.7.1",
     "jsonwebtoken": "^7.2.1",
     "verror": "^1.9.0"
   },


### PR DESCRIPTION
The old node-forge version does some weird stuff that rollup complains about (it tries to delete a local variable).

The breaking changes in 0.7 doesn't seem to affect node-apn.