### PR TITLE
#163, allow connection through HTTP proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ For more information about configuration options consult the [provider documenta
 
 Help with preparing the key and certificate files for connection can be found in the [wiki][certificateWiki]
 
+#### Connecting through an HTTP proxy
+
+If you need to connect through an HTTP proxy, you simply need to provide the `proxy: {host, port}` option when creating the provider. For example:
+
+```javascript
+var options = {
+  token: {
+    key: "path/to/APNsAuthKey_XXXXXXXXXX.p8",
+    keyId: "key-id",
+    teamId: "developer-team-id"
+  },
+  proxy: {
+    host: "192.168.10.92",
+    port: 8080
+  }
+  production: false
+};
+
+var apnProvider = new apn.Provider(options);
+```
+
+The provider will first send an HTTP CONNECT request to the specified proxy in order to establish an HTTP tunnel. Once established, it will create a new secure connection to the Apple Push Notification provider API through the tunnel.
+
 ### Sending a notification
 To send a notification you will first need a device token from your app as a string
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const config = require("./lib/config")({
 });
 
 const tls = require("tls");
+const http = require("http");
 
 const framer     = require("http2/lib/protocol/framer");
 const compressor = require("http2/lib/protocol/compressor");
@@ -26,6 +27,7 @@ const protocol = {
 
 const Endpoint = require("./lib/protocol/endpoint")({
   tls,
+  http,
   protocol,
 });
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,6 +24,7 @@ module.exports = function(dependencies) {
       production: (process.env.NODE_ENV === "production"),
       address: null,
       port: 443,
+      proxy: null,
       rejectUnauthorized: true,
       connectionRetryLimit: 10,
       heartBeat: 60000,

--- a/lib/protocol/endpoint.js
+++ b/lib/protocol/endpoint.js
@@ -18,14 +18,22 @@ const CLIENT_PRELUDE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
 
 module.exports = function(dependencies) {
   const tls = dependencies.tls;
+  const http = dependencies.http;
   const protocol = dependencies.protocol;
 
   function Endpoint(options) {
     EventEmitter.call(this);
 
-    this.options = options;
-    options.host = options.host || options.address;
-    options.servername = options.address;
+    this.options = Object.assign({}, options);
+    this.options.ALPNProtocols = ["h2"];
+    this.options.host = options.host || options.address;
+    this.options.servername = options.address;
+    if (options.proxy){
+      this.options.targetHost = this.options.host;
+      this.options.targetPort = this.options.port;
+      this.options.host = this.options.proxy.host;
+      this.options.port = this.options.proxy.port || this.options.port;
+    }
 
     this._acquiredStreamSlots = 0;
     this._maximumStreamSlots = 0;
@@ -33,10 +41,7 @@ module.exports = function(dependencies) {
     this._pingedThreshold = (this.options.heartBeat || 60000) * 2.5;
     this._heartBeatInterval = (this.options.heartBeat || 60000);
 
-    options.ALPNProtocols = ["h2"];
-
     this._connect();
-    this._setupHTTP2Pipeline();
     this._heartBeatIntervalCheck = this._setupHTTP2HealthCheck();
   }
 
@@ -77,7 +82,34 @@ module.exports = function(dependencies) {
   };
 
   Endpoint.prototype._connect = function connect() {
-    this._socket = tls.connect(this.options);
+    // Connecting directly to the remote host
+    if (!this.options.proxy) {
+      return this._socketOpened(tls.connect(this.options));
+    }
+
+    // Connecting through an HTTP proxy
+    const req = http.request({
+      host: this.options.host,
+      port: this.options.port,
+      method: "CONNECT",
+      headers: { Connection: "Keep-Alive" },
+      path: `${this.options.targetHost}:${this.options.targetPort}`,
+    });
+    req.end();
+
+    req.on("error", this._error.bind(this));
+    req.on("connect", (res, socket) => {
+      const optionsWithProxy = Object.assign({}, this.options, {
+        socket,
+        host: this.options.targetHost,
+        port: this.options.targetPort
+      });
+      this._socketOpened(tls.connect(optionsWithProxy));
+    });
+  };
+
+  Endpoint.prototype._socketOpened = function _socketOpened(socket) {
+    this._socket = socket;
     this._socket.on("secureConnect", this._connected.bind(this));
     this._socket.on("error", this._error.bind(this));
     this._socket.on("close", this._close.bind(this));
@@ -87,6 +119,8 @@ module.exports = function(dependencies) {
     this._connection = new protocol.Connection(noopLogger, 1);
     this._connection.on("error", this._protocolError.bind(this, "connection"));
     this._connection.on("GOAWAY", this._goaway.bind(this));
+
+    this._setupHTTP2Pipeline();
   };
 
   Endpoint.prototype._connected = function connected() {
@@ -184,7 +218,7 @@ module.exports = function(dependencies) {
 
   Endpoint.prototype.destroy = function destroy() {
     clearInterval(this._heartBeatIntervalCheck);
-    this._socket.destroy();
+    if(this._socket) this._socket.destroy();
   };
 
   return Endpoint;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apn",
   "description": "An interface to the Apple Push Notification service for Node.js",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "author": "Andrew Naylor <argon@mkbot.net>",
   "contributors": [
     {

--- a/test/config.js
+++ b/test/config.js
@@ -27,6 +27,7 @@ describe("config", function () {
       production: false,
       address: "api.development.push.apple.com",
       port: 443,
+      proxy: null,
       rejectUnauthorized: true,
       connectionRetryLimit: 10,
       heartBeat: 60000,


### PR DESCRIPTION
This commit fixes #163, adding a proxy option to connect with APN servers using an HTTP proxy