### PR TITLE
Native HTTP/2 (WIP)

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,33 +11,11 @@ const config = require("./lib/config")({
   prepareCA: credentials.ca,
 });
 
-const tls = require("tls");
-const http = require("http");
-
-const framer     = require("http2/lib/protocol/framer");
-const compressor = require("http2/lib/protocol/compressor");
-
-const protocol = {
-  Serializer:   framer.Serializer,
-  Deserializer: framer.Deserializer,
-  Compressor:   compressor.Compressor,
-  Decompressor: compressor.Decompressor,
-  Connection:   require("http2/lib/protocol/connection").Connection,
-};
-
-const Endpoint = require("./lib/protocol/endpoint")({
-  tls,
-  http,
-  protocol,
-});
-
-const EndpointManager = require("./lib/protocol/endpointManager")({
-  Endpoint,
-});
+const http2 = require("http2");
 
 const Client = require("./lib/client")({
   config,
-  EndpointManager,
+  http2,
 });
 
 const Provider = require("./lib/provider")({

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,135 +4,112 @@ const VError = require("verror");
 const extend = require("./util/extend");
 
 module.exports = function (dependencies) {
-  const config          = dependencies.config;
-  const EndpointManager = dependencies.EndpointManager;
+  const config = dependencies.config;
+  const http2 = dependencies.http2;
+
+  const {
+    HTTP2_HEADER_STATUS,
+    HTTP2_HEADER_SCHEME,
+    HTTP2_HEADER_METHOD,
+    HTTP2_HEADER_AUTHORITY,
+    HTTP2_HEADER_PATH,
+    HTTP2_METHOD_POST
+  } = http2.constants;
 
   function Client (options) {
     this.config = config(options);
-
-    this.endpointManager = new EndpointManager(this.config);
-    this.endpointManager.on("wakeup", () => {
-      while (this.queue.length > 0) {
-        const stream = this.endpointManager.getStream();
-        if (!stream) {
-          return;
-        }
-        const resolve = this.queue.shift();
-        resolve(stream);
-      }
-
-      if (this.shutdownPending) {
-        this.endpointManager.shutdown();
-      }
-    });
-
-    this.endpointManager.on("error", (err) => {
-      this.queue.forEach((resolve) => {
-        resolve(Promise.reject(err));
-      });
-
-      this.queue = [];
-    });
-
-    this.queue = [];
   }
 
   Client.prototype.write = function write (notification, device, count) {
-    return this.getStream().then( stream => {
-      let tokenGeneration, status, responseData = "";
-      let retryCount = count || 0;
+    // Connect session
+    if (!this.session || this.session.destroyed) {
+      this.session = http2.connect(`https://${this.config.address}`, this.config);
 
-      stream.setEncoding("utf8");
-
-      stream.on("headers", headers => {
-        status = headers[":status"];
-      });
-
-      stream.on("data", data => {
-        responseData = responseData + data;
-      });
-
-      let headers = extend({
-        ":scheme": "https",
-        ":method": "POST",
-        ":authority": this.config.address,
-        ":path": "/3/device/" + device,
-      }, notification.headers);
-
-      if (this.config.token) {
-        if (this.config.token.isExpired(3300)) {
-          this.config.token.regenerate(this.config.token.generation);
-        }
-        headers.authorization = "bearer " + this.config.token.current;
-        tokenGeneration = this.config.token.generation;
-      }
-
-      stream.headers(headers);
-      stream.write(notification.body);
-
-      return new Promise ( resolve => {
-        stream.on("end", () => {
-          if (status === "200") {
-            resolve({ device });
-          } else if (responseData !== "") {
-            const response = JSON.parse(responseData);
-
-            if (status === "403" && response.reason === "ExpiredProviderToken" && retryCount < 2) {
-              this.config.token.regenerate(tokenGeneration);
-              resolve(this.write(notification, device, retryCount + 1));
-              return;
-            } else if (status === "500" && response.reason === "InternalServerError") {
-              stream.connection.close();
-              let error = new VError("Error 500, stream ended unexpectedly");
-              resolve({ device, error });
-              return;
-            }
-
-            resolve({ device, status, response });
-          } else {
-            let error = new VError("stream ended unexpectedly");
-            resolve({ device, error });
-          }
-        });
-
-        stream.on("unprocessed", () => {
-          resolve(this.write(notification, device));
-        });
-
-        stream.on("error", err => {
-          let error;
-          if (typeof err === "string") {
-            error = new VError("apn write failed: %s", err);
-          } else {
-            error = new VError(err, "apn write failed");
-          }
-          resolve({ device, error });
-        });
-
-        stream.end();
-      });
-    }).catch( error => {
-      return { device, error };
-    });
-  };
-
-  Client.prototype.getStream = function getStream() {
-    return new Promise( resolve => {
-      const stream = this.endpointManager.getStream();
-      if (!stream) {
-        this.queue.push(resolve);
-      } else {
-        resolve(stream);
-      }
-    });
-  };
-
-  Client.prototype.shutdown = function shutdown() {
-    if (this.queue.length > 0) {
-      this.shutdownPending = true;
-      return;
+      this.session.on('socketError', (err) => console.error(err));
+      this.session.on('error', (err) => console.error(err));
     }
-    this.endpointManager.shutdown();
+
+    let tokenGeneration = null;
+    let status = null;
+    let responseData = "";
+    let retryCount = count || 0;
+
+    const headers = extend({
+      [HTTP2_HEADER_SCHEME]: "https",
+      [HTTP2_HEADER_METHOD]: HTTP2_METHOD_POST,
+      [HTTP2_HEADER_AUTHORITY]: this.config.address,
+      [HTTP2_HEADER_PATH]: `/3/device/${device}`,
+    }, notification.headers);
+
+    if (this.config.token) {
+      if (this.config.token.isExpired(3300)) {
+        this.config.token.regenerate(this.config.token.generation);
+      }
+      headers.authorization = `bearer ${this.config.token.current}`;
+      tokenGeneration = this.config.token.generation;
+    }
+
+    const request = this.session.request(headers)
+
+    request.setEncoding("utf8");
+
+    request.on("response", (headers) => {
+      status = headers[HTTP2_HEADER_STATUS];
+    });
+
+    request.on("data", (data) => {
+      responseData += data;
+    });
+
+    request.write(notification.body);
+
+    return new Promise ( resolve => {
+      request.on("end", () => {
+        if (status === 200) {
+          resolve({ device });
+        } else if (responseData !== "") {
+          const response = JSON.parse(responseData);
+
+          if (status === 403 && response.reason === "ExpiredProviderToken" && retryCount < 2) {
+            this.config.token.regenerate(tokenGeneration);
+            resolve(this.write(notification, device, retryCount + 1));
+            return;
+          } else if (status === 500 && response.reason === "InternalServerError") {
+            this.session.destroy();
+            let error = new VError("Error 500, stream ended unexpectedly");
+            resolve({ device, error });
+            return;
+          }
+
+          resolve({ device, status, response });
+        } else {
+          let error = new VError("stream ended unexpectedly");
+          resolve({ device, error });
+        }
+      })
+
+      request.on("error", (error) => {
+        if (typeof error === "string") {
+          error = new VError("apn write failed: %s", err);
+        } else {
+          error = new VError(error, "apn write failed");
+        }
+        resolve({ device, error });
+      });
+
+      request.end();
+    });
+  };
+
+  Client.prototype.shutdown = function shutdown(callback) {
+    if (this.session && !this.session.destroyed) {
+      this.session.shutdown({graceful: true}, () => {
+        session.destroy();
+        if (callback) {
+          callback();
+        }
+      });
+    }
   };
 
   return Client;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,436 @@
+{
+  "name": "apn",
+  "version": "3.0.0-alpha",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "1.0.2"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
+      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "requires": {
+        "base64url": "2.0.0",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
+      "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "jsonwebtoken": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.0.tgz",
+      "integrity": "sha1-xjl80uX9WD1lwAeoPce7eOaYK4M=",
+      "requires": {
+        "jws": "3.1.4",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.0.0",
+        "xtend": "4.0.1"
+      }
+    },
+    "jwa": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
+      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "requires": {
+        "base64url": "2.0.0",
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.9",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
+      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "requires": {
+        "base64url": "2.0.0",
+        "jwa": "1.1.5",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node-forge": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
+      "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
+      }
+    },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.4.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apn",
   "description": "An interface to the Apple Push Notification service for Node.js",
-  "version": "2.1.6",
+  "version": "3.0.0-alpha",
   "author": "Andrew Naylor <argon@mkbot.net>",
   "contributors": [
     {
@@ -28,18 +28,17 @@
     "url": "https://github.com/node-apn/node-apn.git"
   },
   "dependencies": {
-    "debug": "^2.6.8",
-    "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
+    "debug": "^3.1.0",
+    "jsonwebtoken": "^8.1.0",
     "node-forge": "^0.7.1",
-    "jsonwebtoken": "^7.4.1",
     "verror": "^1.10.0"
   },
   "devDependencies": {
     "chai": "3.x",
-    "chai-as-promised": "*",
-    "mocha": "*",
+    "chai-as-promised": "^7.1.1",
+    "mocha": "^4.0.1",
     "sinon": "^1.12.2",
-    "sinon-chai": "^2.6.0"
+    "sinon-chai": "^2.14.0"
   },
   "scripts": {
     "test": "node_modules/.bin/mocha"
@@ -55,7 +54,7 @@
     }
   },
   "engines": {
-    "node": ">= 4.6.0"
+    "node": ">= 8.9.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Switch to node's native HTTP/2 client.

This works for sending notifications, but is still work in progress. Some features are still missing, e.g. connecting through a proxy and sending a heartbeat ping.