### PR TITLE
Set the HTTP/2 session's event listener count to infinity to address warnings

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -27,6 +27,7 @@ module.exports = function (dependencies) {
     // Connect session
     if (!this.session || this.session.destroyed) {
       this.session = http2.connect(`https://${this.config.address}`, this.config);
+      this.session.setMaxListeners(Infinity);
 
       this.session.on("socketError", (error) => {
         if (logger.enabled) {


### PR DESCRIPTION
When sending notifications using a newly constructed APN provider all at once, the HTTP/2 session will queue up the calls to `this.session.request()`. Internally, the HTTP/2 session adds a "connect" event listener for each request since it needs to wait until the connection has been established before it can actually send the requests.

As a result, if more than 10 notifications are sent at once (to a new APN provider whose HTTP/2 session is still setting up the connection), the HTTP/2 session will add more than 10 "connect" event listeners, triggering a MaxListenersExceededWarning. Setting the max listener count to infinity addresses this warning.

Additionally, looking through the code, the APN client doesn't otherwise add an unbounded number of event listeners to the HTTP/2 session (listeners are mostly added just once, when the session is constructed), so this commit shouldn't hide actual problems.