### PR TITLE
Throw an error during validation when there is no certificate

### DIFF
--- a/lib/credentials/certificate/validate.js
+++ b/lib/credentials/certificate/validate.js
@@ -2,6 +2,9 @@
 
 function validateCredentials(credentials) {
   let certificate = credentials.certificates[0];
+  if (!certificate) {
+    throw new Error("certificate is missing");
+  }
 
   if (credentials.key.fingerprint() !== certificate.key().fingerprint()) {
     throw new Error("certificate and key do not match");

--- a/test/credentials/certificate/validate.js
+++ b/test/credentials/certificate/validate.js
@@ -19,6 +19,16 @@ describe("validateCredentials", function() {
     });
   });
 
+  describe("with missing certificate", function() {
+    it("throws", function() {
+      credentials.certificates = [];
+
+      expect(function() {
+        validateCredentials(credentials);
+      }).to.throw(/certificate is missing/);
+    });
+  });
+
   describe("with mismatched key and certificate", function() {
     it("throws", function() {
       sinon.stub(credentials.certificates[0]._key, "fingerprint").returns("fingerprint2");


### PR DESCRIPTION
When there is no certificate (ex: if the p12 file is missing one), the `certificates` array is empty. This causes an exception later in the code along the lines of "TypeError: Cannot read property 'key' of undefined" because `certificate` is undefined. This commit specifically checks for a missing certificate and throws a clearer error message instead.

Tested by adding a new unit test.