### PR TITLE
Fix Client.shutdown to use correct close function

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -143,7 +143,7 @@ module.exports = function (dependencies) {
 
   Client.prototype.shutdown = function shutdown(callback) {
     if (this.session && !this.session.destroyed) {
-      this.session.shutdown({graceful: true}, () => {
+      this.session.close(() => {
         this.session.destroy();
         if (callback) {
           callback();


### PR DESCRIPTION
As corrected by @mikemliu in #633, the Client and thus the Provider shutdown is not properly written in the native Http2 implementation.