### PR TITLE
Add support for critical alert sounds

### DIFF
--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -74,7 +74,7 @@ module.exports = {
   },
 
   set sound(value) {
-    if (typeof value === "string" || value === undefined) {
+    if (typeof value === "string" || typeof value === "object" && value !== null || value === undefined) {
       this.aps.sound = value;
     }
   },


### PR DESCRIPTION
APNs now supports a dictionary for the `aps.sound` field, which can contain fields pertaining to critical alerts. This commit lets node-apn take a dictionary for the `sound` field. See: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2990112