### PR TITLE
Fix issue 543 by clearing health check interval on endpoint close

### DIFF
--- a/lib/protocol/endpoint.js
+++ b/lib/protocol/endpoint.js
@@ -210,6 +210,8 @@ module.exports = function(dependencies) {
   };
 
   Endpoint.prototype.close = function close() {
+    clearInterval(this._heartBeatIntervalCheck);
+
     if (this._acquiredStreamSlots === 0) {
       this._connection.close();
     }


### PR DESCRIPTION
Another take on solving #543, based on @dmrdev's suggestion. This minimal approach adds only one line of code, clearing health check interval on endpoint close. Currently there are two more PRs open aiming to solve the same problem - #551 and #554.