### PR TITLE
Important: Add support for apns-push-type

### DIFF
--- a/doc/notification.markdown
+++ b/doc/notification.markdown
@@ -172,6 +172,14 @@ Provide one of the following values:
   * `5` - The push message is sent at a time that conserves power on the device receiving it.
 
 
+#### notification.pushType
+
+(Required when delivering notifications to devices running iOS 13 and later, or watchOS 6 and later. Ignored on earlier system versions.)
+
+The type of the notification. The value of this header is `alert` or `background`. Specify `alert` when the delivery of your notification displays an alert, plays a sound, or badges your app's icon. Specify `background` for silent notifications that do not interact with the user.
+
+The value of this header must accurately reflect the contents of your notification's payload. If there is a mismatch, or if the header is missing on required systems, APNs may delay the delivery of the notification or drop it altogether.
+
 #### notification.collapseId
 
 Multiple notifications with same collapse identifier are displayed to the user as a single notification. The value should not exceed 64 bytes.

--- a/index.d.ts
+++ b/index.d.ts
@@ -150,6 +150,7 @@ export class Notification {
   public priority: number;
 
   public collapseId: string;
+  public pushType: string;
   public threadId: string;
 
   /**

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -58,6 +58,10 @@ Notification.prototype.headers = function headers() {
     headers["apns-collapse-id"] = this.collapseId;
   }
 
+  if (this.pushType) {
+    headers["apns-push-type"] = this.pushType;
+  }
+
   return headers;
 };
 

--- a/test/notification/index.js
+++ b/test/notification/index.js
@@ -154,6 +154,14 @@ describe("Notification", function() {
 				expect(note.headers()).to.have.property("apns-collapse-id", "io.apn.collapse");
 			});
 		});
+
+		context("pushType is set", function () {
+			it("contains the apns-push-type header", function () {
+				note.pushType = "alert";
+
+				expect(note.headers()).to.have.property("apns-push-type", "alert");
+			});
+		});
 	});
 
 	describe("compile", function() {


### PR DESCRIPTION
This is a new header key for APNS. **Required when delivering notifications to devices running iOS 13 and later, or watchOS 6 and later.**

Related apple docs: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns