### PR TITLE
Add proxy options in Provider Options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,11 +17,26 @@ export interface ProviderToken {
   teamId: string;
 }
 
+export interface ProxyOptions {
+  /**
+   * The proxy host
+   */
+  host: string;
+  /**
+   * The proxy port
+   */
+  port: number;
+}
+
 export interface ProviderOptions {
   /**
    * Configuration for Provider Authentication Tokens. (Defaults to: null i.e. fallback to Certificates)
    */
   token?: ProviderToken;
+  /**
+   * Configuration for Proxy. (Defaults to: null)
+   */
+  proxy?: ProxyOptions;
   /**
    * The filename of the connection certificate to load from disk, or a Buffer/String containing the certificate data. (Defaults to: `cert.pem`)
    */


### PR DESCRIPTION
The property `proxy` is missing in type definitions.

- Add interface for `ProxyOptions`.
- Add missing `proxy` optional field in `ProviderOptions` 

