### PR TITLE
Update node-forge to 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -423,9 +423,9 @@
       }
     },
     "node-forge": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
-      "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "debug": "^3.1.0",
     "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
-    "node-forge": "^0.7.1",
     "jsonwebtoken": "^8.1.0",
+    "node-forge": "^0.10.0",
     "verror": "^1.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Security fix for node-forge dependency — https://github.com/advisories/GHSA-92xj-mqp7-vmcj