### PR TITLE
Improve proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ var options = {
   },
   proxy: {
     host: "192.168.10.92",
-    port: 8080
+    port: 8080,
+    username: "user", // optional
+    password: "secretPassword" // optional
   },
   production: false
 };

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Help with preparing the key and certificate files for connection can be found in
 
 #### Connecting through an HTTP proxy
 
-If you need to connect through an HTTP proxy, you simply need to provide the `proxy: {host, port}` option when creating the provider. For example:
+The provider will retrieve HTTP proxy connection info from the system environment variables `apn_proxy`, `http_proxy`/`https_proxy`. If you for some reason need to connect through another specific HTTP proxy, you simply need to provide the `proxy: {host, port}` option when creating the provider. For example:
 
 ```javascript
 var options = {
@@ -98,7 +98,9 @@ var options = {
 var apnProvider = new apn.Provider(options);
 ```
 
-The provider will first send an HTTP CONNECT request to the specified proxy in order to establish an HTTP tunnel. Once established, it will create a new secure connection to the Apple Push Notification provider API through the tunnel.
+To disable this default HTTP proxy behaviour, simply set the `proxy: false`.
+
+When enabled, the provider will first send an HTTP CONNECT request to the specified proxy in order to establish an HTTP tunnel. Once established, it will create a new secure connection to the Apple Push Notification provider API through the tunnel.
 
 ### Sending a notification
 To send a notification you will first need a device token from your app as a string

--- a/lib/protocol/endpoint.js
+++ b/lib/protocol/endpoint.js
@@ -87,16 +87,26 @@ module.exports = function(dependencies) {
       return this._socketOpened(tls.connect(this.options));
     }
 
-    // Connecting through an HTTP proxy
-    const req = http.request({
+    // Initialize proxy request
+    const proxyRequestOptions = {
       host: this.options.host,
       port: this.options.port,
       method: "CONNECT",
       headers: { Connection: "Keep-Alive" },
       path: `${this.options.targetHost}:${this.options.targetPort}`,
-    });
-    req.end();
+    }
 
+    // Add proxy basic authentication header
+    if (this.options.username) {
+      const auth = `${this.options.username || ''}:${this.options.password || ''}`;
+      const base64 = Buffer.from(auth, 'utf8').toString('base64');
+
+      proxyRequestOptions.headers['Proxy-Authorization'] = 'Basic ' + base64;
+    }
+
+    // Connecting through an HTTP proxy
+    const req = http.request(proxyRequestOptions);
+    
     req.on("error", this._error.bind(this));
     req.on("connect", (res, socket) => {
       const optionsWithProxy = Object.assign({}, this.options, {

--- a/lib/protocol/endpoint.js
+++ b/lib/protocol/endpoint.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const EventEmitter = require("events");
+const getSystemProxy = require("./proxy/getSystemProxy");
 
 const noop = () => {};
 const noopLogger = {
@@ -28,11 +29,18 @@ module.exports = function(dependencies) {
     this.options.ALPNProtocols = ["h2"];
     this.options.host = options.host || options.address;
     this.options.servername = options.address;
-    if (options.proxy){
+
+    const proxyOptions = this.options.proxy || getSystemProxy(this.options.port);    
+    if (proxyOptions) {
       this.options.targetHost = this.options.host;
       this.options.targetPort = this.options.port;
-      this.options.host = this.options.proxy.host;
-      this.options.port = this.options.proxy.port || this.options.port;
+      this.options.host = proxyOptions.host;
+      this.options.port = proxyOptions.port || this.options.port;
+      
+      if (proxyOptions.username || proxyOptions.password) {
+        this.options.username = proxyOptions.username;
+        this.options.password = proxyOptions.password;
+      }
     }
 
     this._acquiredStreamSlots = 0;

--- a/lib/protocol/endpoint.js
+++ b/lib/protocol/endpoint.js
@@ -2,6 +2,7 @@
 
 const EventEmitter = require("events");
 const getSystemProxy = require("./proxy/getSystemProxy");
+const shouldProxy = require("./proxy/shouldProxy");
 
 const noop = () => {};
 const noopLogger = {
@@ -30,8 +31,11 @@ module.exports = function(dependencies) {
     this.options.host = options.host || options.address;
     this.options.servername = options.address;
 
-    const proxyOptions = this.options.proxy || getSystemProxy(this.options.port);    
-    if (proxyOptions) {
+    const proxyOptions = options.proxy || getSystemProxy(this.options.port);
+    this.options.useProxy = options.proxy !== false && 
+      proxyOptions && shouldProxy(this.options.host, this.options.port);
+    
+    if (this.options.useProxy) {
       this.options.targetHost = this.options.host;
       this.options.targetPort = this.options.port;
       this.options.host = proxyOptions.host;
@@ -91,7 +95,7 @@ module.exports = function(dependencies) {
 
   Endpoint.prototype._connect = function connect() {
     // Connecting directly to the remote host
-    if (!this.options.proxy) {
+    if (!this.options.useProxy) {
       return this._socketOpened(tls.connect(this.options));
     }
 
@@ -114,7 +118,8 @@ module.exports = function(dependencies) {
 
     // Connecting through an HTTP proxy
     const req = http.request(proxyRequestOptions);
-    
+    req.end();
+
     req.on("error", this._error.bind(this));
     req.on("connect", (res, socket) => {
       const optionsWithProxy = Object.assign({}, this.options, {

--- a/lib/protocol/proxy/getSystemProxy.js
+++ b/lib/protocol/proxy/getSystemProxy.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const getEnv = require("../../util/getEnv");
+
+/**
+ * Get proxy connection info from the system environment variables
+ * Gathers connection info from environment variables in the following order:
+ *   1. npm_config_apn_proxy
+ *   2. apn_proxy
+ *   3. npm_config_http/https_proxy (https if targetPort: 443)
+ *   4. http/https_proxy (https if targetPort: 443)
+ *   5. npm_config_proxy
+ *   6. proxy
+ * 
+ * @param {number} targetPort - Port number for the target host/webpage.
+ * @returns {Object} proxy - Object containing proxy information from the environment.
+ * @returns {string} proxy.host - Proxy hostname
+ * @returns {string} proxy.origin - Proxy port number
+ * @returns {string} proxy.port - Proxy port number
+ * @returns {string} proxy.protocol - Proxy connection protocol
+ * @returns {string} proxy.username - Username for connecting to the proxy
+ * @returns {string} proxy.password - Password for connecting to the proxy
+ */
+module.exports = function getSystemProxy(targetPort) {
+    const protocol = targetPort === 443 ? "https" : "http";
+    let proxy = getEnv('npm_config_apn_proxy') || getEnv('apn_proxy') ||
+        getEnv(`npm_config_${protocol}_proxy`) || getEnv(`${protocol}_proxy`) ||
+        getEnv('npm_config_proxy') || getEnv('proxy');
+    
+    // No proxy environment variable set
+    if (!proxy) return null;
+
+    // Append protocol scheme if missing from proxy url
+    if (proxy.indexOf('://') === -1) {
+        proxy = `${protocol}://${proxy}`;
+    }
+
+    // Parse proxy as Url to easier extract info
+    const parsedProxy = new URL(proxy);
+    return {
+        host: parsedProxy.hostname || parsedProxy.host,
+        origin: parsedProxy.origin,
+        port: parsedProxy.port,
+        protocol: parsedProxy.protocol,
+        username: parsedProxy.username,
+        password: parsedProxy.password
+    }
+};

--- a/lib/protocol/proxy/getSystemProxy.js
+++ b/lib/protocol/proxy/getSystemProxy.js
@@ -5,10 +5,10 @@ const getEnv = require("../../util/getEnv");
 /**
  * Get proxy connection info from the system environment variables
  * Gathers connection info from environment variables in the following order:
- *   1. npm_config_apn_proxy
- *   2. apn_proxy
- *   3. npm_config_http/https_proxy (https if targetPort: 443)
- *   4. http/https_proxy (https if targetPort: 443)
+ *   1. apn_proxy
+ *   2. npm_config_http/https_proxy (https if targetPort: 443)
+ *   3. http/https_proxy (https if targetPort: 443)
+ *   4. all_proxy
  *   5. npm_config_proxy
  *   6. proxy
  * 
@@ -23,9 +23,8 @@ const getEnv = require("../../util/getEnv");
  */
 module.exports = function getSystemProxy(targetPort) {
     const protocol = targetPort === 443 ? "https" : "http";
-    let proxy = getEnv('npm_config_apn_proxy') || getEnv('apn_proxy') ||
-        getEnv(`npm_config_${protocol}_proxy`) || getEnv(`${protocol}_proxy`) ||
-        getEnv('npm_config_proxy') || getEnv('proxy');
+    let proxy = getEnv('apn_proxy') || getEnv(`npm_config_${protocol}_proxy`) || getEnv(`${protocol}_proxy`) ||
+        getEnv('all_proxy') || getEnv('npm_config_proxy') || getEnv('proxy');
     
     // No proxy environment variable set
     if (!proxy) return null;

--- a/lib/protocol/proxy/shouldProxy.js
+++ b/lib/protocol/proxy/shouldProxy.js
@@ -31,9 +31,9 @@ module.exports = function shouldProxy(hostname, port) {
 
     // Replace wildcard characters in the hostname with regular expression wildcards
     const regexProxyHost = escapedProxyHost
-        .replace(/\\\*/g, ".*")
         .replace(/^\\\./, "\\*.") // Leading dot = wildcard
-        .replace(/\\\.$/, "\\*."); // Trailing dot = wildcard
+        .replace(/\\\.$/, "\\*.") // Trailing dot = wildcard
+        .replace(/\\\*/g, ".*");
 
     // Test the hostname against the regular expression
     return !(new RegExp(`^${regexProxyHost}$`).test(hostname));

--- a/lib/protocol/proxy/shouldProxy.js
+++ b/lib/protocol/proxy/shouldProxy.js
@@ -18,8 +18,15 @@ module.exports = function shouldProxy(hostname, port) {
     if (!path) return true;
 
     // Parse path to separate host and port
-    const [, proxyHost, proxyPort] = path.match(/^([^\:]+)?(?::(\d+))?$/);
-    if (proxyPort && parseInt(proxyPort) !== port) return true;
+    const match = path.match(/^([^\:]+)?(?::(\d+))?$/);
+    const proxyHost = match[1] || ""
+    const proxyPort = match[2] ? parseInt(match[2]) : ""
+    
+    // If port is specified and it doesn't match
+    if (proxyPort && proxyPort !== port) return true;
+
+    // No hostname, but matching port is specified
+    if (proxyPort && !proxyHost) return false;
 
     // If no wildcards or beginning with dot, return if exact match
     if (!/^[.*]/.test(proxyHost)) {

--- a/lib/protocol/proxy/shouldProxy.js
+++ b/lib/protocol/proxy/shouldProxy.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const getEnv = require("../../util/getEnv");
+
+/**
+ * Checks the `no_proxy` environment variable if a hostname (and port) should be proxied or not.
+ * 
+ * @param {string} hostname - Hostname of the page we are connecting to (not the proxy itself)
+ * @param {string} port - Effective port number for the host
+ * @returns {boolean} Whether the hostname should be proxied or not
+ */
+module.exports = function shouldProxy(hostname, port) {
+  const noProxy = `${getEnv("no_proxy") || getEnv("npm_config_no_proxy")}`.toLowerCase();
+  if (!noProxy || noProxy === "*") return true; // No proxy restrictions are set or everything should be proxied
+
+  // Loop all excluded paths and check if host matches
+  return noProxy.split(/[,\s]+/).every(function(path) {
+    if (!path) return true;
+
+    // Parse path to separate host and port
+    const [, proxyHost, proxyPort] = path.match(/^([^\:]+)?(?::(\d+))?$/);
+    if (proxyPort && parseInt(proxyPort) !== port) return true;
+
+    // If no wildcards or beginning with dot, return if exact match
+    if (!/^[.*]/.test(proxyHost)) {
+        if (hostname === proxyHost) return false;
+    }
+
+    // Escape any special characters in the hostname
+    const escapedProxyHost = proxyHost.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+
+    // Replace wildcard characters in the hostname with regular expression wildcards
+    const regexProxyHost = escapedProxyHost
+        .replace(/\\\*/g, ".*")
+        .replace(/^\\\./, "\\*.") // Leading dot = wildcard
+        .replace(/\\\.$/, "\\*."); // Trailing dot = wildcard
+
+    // Test the hostname against the regular expression
+    return !(new RegExp(`^${regexProxyHost}$`).test(hostname));
+  });
+};

--- a/lib/util/getEnv.js
+++ b/lib/util/getEnv.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * Get environment variable regardless of casing (upper/lowercase).
+ * @param {string} key - Name of the environment variable
+ * @returns {string} Value of the environment variable or empty string
+ */
+module.exports = function getEnv(key) {
+  if (!process || !process.env) return '';
+  return process.env[key.toUpperCase()] || process.env[key.toLowerCase()] || '';
+};

--- a/test/protocol/endpoint.js
+++ b/test/protocol/endpoint.js
@@ -169,8 +169,9 @@ describe("Endpoint", function () {
       });
     });
 
-    describe("HTTP proxy config", function() {
+    context("HTTP proxy env config", function() {
       const getSystemProxy = require("../../lib/protocol/proxy/getSystemProxy")
+      const shouldProxy = require("../../lib/protocol/proxy/shouldProxy")
       var env;
 
       // Mock environment and backup original
@@ -178,7 +179,8 @@ describe("Endpoint", function () {
         env = process.env;
         process.env = { 
           "http_proxy": "http://user1:pass@localhost:8080",
-          "https_proxy": "http://user2:pass@localhost:8081"
+          "https_proxy": "http://user2:pass@localhost:8081",
+          "no_proxy": "*.example.com,example.com,.example.org,localhost:443,:4444"
         };
       });
 
@@ -194,6 +196,18 @@ describe("Endpoint", function () {
         expect(proxy).to.have.property("username", "user2")
         expect(proxy).to.have.property("port", "8081")
         expect(proxy).to.have.property("protocol", "http:")
+      });
+
+      it("respects no_proxy env", function() {
+        expect(shouldProxy("test.example.com", 443)).to.equal(false) // Matches: *.example.com
+        expect(shouldProxy("example.com", 443)).to.equal(false) // Matches: example.com
+        expect(shouldProxy("test.example.org", 443)).to.equal(false) // Matches: *.example.org
+        expect(shouldProxy("example.org", 443)).to.equal(true) // Should NOT match: *.example.org
+        expect(shouldProxy("localhost", 443)).to.equal(false) // Should match: localhost:443
+        expect(shouldProxy("localhost", 80)).to.equal(true) // Should not match: localhost:443
+        expect(shouldProxy("localhost", 4444)).to.equal(false) // Should match: :4444
+        expect(shouldProxy("example.org", 4444)).to.equal(false) // Should match: :4444
+        expect(shouldProxy("differentdomain", 8080)).to.equal(true) // Should not match anything..
       });
 
       // restoring system envs back

--- a/test/protocol/endpoint.js
+++ b/test/protocol/endpoint.js
@@ -169,6 +169,39 @@ describe("Endpoint", function () {
       });
     });
 
+    describe("HTTP proxy config", function() {
+      const getSystemProxy = require("../../lib/protocol/proxy/getSystemProxy")
+      var env;
+
+      // Mock environment and backup original
+      before(function () {
+        env = process.env;
+        process.env = { 
+          "http_proxy": "http://user1:pass@localhost:8080",
+          "https_proxy": "http://user2:pass@localhost:8081"
+        };
+      });
+
+      it("retrieves http proxy config from env", function() {
+        const proxy = getSystemProxy(80);
+        expect(proxy).to.have.property("username", "user1")
+        expect(proxy).to.have.property("port", "8080")
+        expect(proxy).to.have.property("protocol", "http:")
+      });
+
+      it("retrieves https proxy config from env", function() {
+        const proxy = getSystemProxy(443);
+        expect(proxy).to.have.property("username", "user2")
+        expect(proxy).to.have.property("port", "8081")
+        expect(proxy).to.have.property("protocol", "http:")
+      });
+
+      // restoring system envs back
+      after(function () {
+        process.env = env;
+      });
+    });
+
     context("using an HTTP proxy", function () {
       let endpointOptions;
       let fakeHttpRequest;
@@ -177,7 +210,10 @@ describe("Endpoint", function () {
         endpointOptions = {
           address: "localtest", 
           port: 443,
-          proxy: {host: "proxyaddress", port: 8080}
+          proxy: {
+            host: "proxyaddress", 
+            port: 8080
+          }
         };
 
         fakeHttpRequest = new EventEmitter();


### PR DESCRIPTION
Hi, I ran into some problems when using this package in Kubernetes using a HTTP proxy that requires authentication, so I made some improvements to the HTTP proxy implementation.

Improvements:

1. Added optional `username` and `password` proxy options. When specified this will set the `Proxy-Authorization` header with basic authentication.
    ```javascript
    var options = {
      token: {
        key: "path/to/APNsAuthKey_XXXXXXXXXX.p8",
        keyId: "key-id",
        teamId: "developer-team-id"
      },
      proxy: {
        host: "192.168.10.92",
        port: 8080,
        username: "secretUsername",
        password: "secretPassword"
      },
      production: false
    };
    
    var apnProvider = new apn.Provider(options);
    ```
2. Added support for retrieving HTTP proxy config from environment variables, instead of needing to specify it in options.
    This is useful in environments where HTTP proxy is configured automatically through Kubernetes for example. This also follows a normal convention across tools and other request libraries, and is normally the expected behaviour ([reference](https://everything.curl.dev/usingcurl/proxies/env)).
    When one of the following environment variables is set we're using this value to connect (in this order):
  
    1. `apn_proxy`
    2. `npm_config_[http/https]_proxy` ([npm config variable for http or https proxy](https://docs.npmjs.com/cli/v9/using-npm/config#https-proxy))
    3. `[http/https]_proxy`
    4. `all_proxy`
    5. `npm_config_proxy` ([npm config variable for general proxy](https://docs.npmjs.com/cli/v9/using-npm/config#proxy))
    6. `proxy`
    
    To completely disable proxies and ignore environment variables set `{ proxy: false }`. This is similar to how [axios](https://www.npmjs.com/package/axios) is handling proxy config.

3. Added support for the `no_proxy` environment variable that makes sure urls that shouldn't be proxied isn't. This is also a commonly supported variable across tools, and is become a convention. ([Reference](https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/)).